### PR TITLE
Remove version from galaxy.yml

### DIFF
--- a/galaxy.yml
+++ b/galaxy.yml
@@ -8,9 +8,6 @@ namespace: symantec
 # The name of the collection. Has the same character restrictions as 'namespace'
 name: epm
 
-# The version of the collection. Must be compatible with semantic versioning
-version: 0.0.1
-
 # The path to the Markdown (.md) readme file. This path is relative to the root of the collection
 readme: README.md
 


### PR DESCRIPTION
This is no longer needed, as we inject the version number based on git
sha1.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>